### PR TITLE
fix: update broken hover-plugin to 3.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CHANGELOG
 
+## 1.2.0
+* akashic-hover-plugin\@3.2.2 に更新
+
 ## 1.1.1
 * g.game.external.atsumaru.getSelfInformationProto() がある環境に対応
 

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ import { resolvePlayerInfo } from "@akashic-extension/resolve-player-info");
 
 ```javascript
 var nameTable = {};
-g.game.onPlayerInfo(function (ev) {
+g.game.onPlayerInfo.add(function (ev) {
   // ev.player.id にプレイヤーIDが、ev.player.name にそのプレイヤーの名前が含まれます。
   // ここで取得しなくても、以降そのプレイヤーが生成したイベントはすべて .player.name で名前を参照できます。
   nameTable[ev.player.id] = ev.player.name;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "@akashic-extension/resolve-player-info",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@akashic-extension/resolve-player-info",
-      "version": "1.1.0",
+      "version": "1.2.0",
       "license": "MIT",
       "dependencies": {
-        "@akashic-extension/akashic-hover-plugin": "~3.0.0"
+        "@akashic-extension/akashic-hover-plugin": "~3.2.2"
       },
       "devDependencies": {
         "@akashic-extension/coe-messages": "~3.1.0",
@@ -22,9 +22,9 @@
       }
     },
     "node_modules/@akashic-extension/akashic-hover-plugin": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@akashic-extension/akashic-hover-plugin/-/akashic-hover-plugin-3.0.0.tgz",
-      "integrity": "sha512-E3uhhLkXYZTiJoOOtLB7dr/L5L0AAQri7x1+Sxyr3lrheuZPvbmbfMwRGthqcQ1+84AIx8z0MsIL1g1ISDUHcw==",
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@akashic-extension/akashic-hover-plugin/-/akashic-hover-plugin-3.2.2.tgz",
+      "integrity": "sha512-Fn1Wj4yaRFHJystwW6m+xifRHFupWRd6J5ZwKxuqch1BI9Na+GbhrybRXsoLkUms1MEUN/gzzSVF5jioXWHaiA==",
       "dependencies": {
         "@akashic/akashic-engine": "~3.0.0"
       }
@@ -2509,9 +2509,9 @@
   },
   "dependencies": {
     "@akashic-extension/akashic-hover-plugin": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@akashic-extension/akashic-hover-plugin/-/akashic-hover-plugin-3.0.0.tgz",
-      "integrity": "sha512-E3uhhLkXYZTiJoOOtLB7dr/L5L0AAQri7x1+Sxyr3lrheuZPvbmbfMwRGthqcQ1+84AIx8z0MsIL1g1ISDUHcw==",
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@akashic-extension/akashic-hover-plugin/-/akashic-hover-plugin-3.2.2.tgz",
+      "integrity": "sha512-Fn1Wj4yaRFHJystwW6m+xifRHFupWRd6J5ZwKxuqch1BI9Na+GbhrybRXsoLkUms1MEUN/gzzSVF5jioXWHaiA==",
       "requires": {
         "@akashic/akashic-engine": "~3.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@akashic-extension/resolve-player-info",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "description": "ユーザー用のプレイヤー名取得ライブラリ",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",
@@ -27,7 +27,7 @@
     "akashic-lib.json"
   ],
   "dependencies": {
-    "@akashic-extension/akashic-hover-plugin": "~3.0.0"
+    "@akashic-extension/akashic-hover-plugin": "~3.2.2"
   },
   "devDependencies": {
     "@akashic-extension/coe-messages": "~3.1.0",


### PR DESCRIPTION
掲題どおり。
akashic-hover-plugin@3.0.0 の不具合修正に追従するため更新します。

npm pack したものを手元のコンテンツで利用し、修正後の `resolverPlayerInfo()` 呼び出しが正しく動作することを確認しています。
